### PR TITLE
Improve dockerfile to cache build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,15 @@
 FROM gradle:8-jdk21 AS build
 WORKDIR /workspace/app
 
+# Copy only gradle files to container so we can install them
+COPY ./build.gradle ./settings.gradle /workspace/app/
+
+# install dependencies. This will be cached by the docker layered cache. This command will fail because the
+# app code is still missing, so we return 0 so docker thinks the command executed successfully (but the
+# dependencies are still downloaded even if the command fails so now we have them cached)
+RUN gradle clean build -x test || return 0
+
+# Now copy the actual app code and build it
 COPY . /workspace/app
 RUN gradle clean build -x test
 RUN mkdir -p build/dependency && (cd build/dependency; jar -xf ../libs/*-SNAPSHOT.jar)


### PR DESCRIPTION
This dockerfile is already in use in other services and in the microservice template, but the media_service's dockerfile was never updated to this iteration.

It caches the different build steps of the docker image, dramatically speeding up build times for subsequent docker builds.