### PR TITLE
Increase internal upload/download url expiration to maximum

### DIFF
--- a/src/main/java/de/unistuttgart/iste/meitrex/media_service/service/MediaService.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/media_service/service/MediaService.java
@@ -547,7 +547,7 @@ public class MediaService {
                         .method(Method.PUT)
                         .bucket(bucketId)
                         .object(filename)
-                        .expiry(15, TimeUnit.MINUTES)
+                        .expiry(7, TimeUnit.DAYS) // maximum per S3 spec
                         .build());
     }
 
@@ -569,7 +569,7 @@ public class MediaService {
                         .method(Method.GET)
                         .bucket(bucketId)
                         .object(filename)
-                        .expiry(15, TimeUnit.MINUTES)
+                        .expiry(7, TimeUnit.DAYS) // maximum per S3 spec
                         .build());
     }
 


### PR DESCRIPTION
Increases the expiration duration of the internal upload download urls to the maximum allowed per the S3 spec (7 days).