### PR TITLE
Minio config & _internal_noauth_mediaRecordsByContentIds query

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,8 +60,10 @@ services:
       - minio
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://database:5432/media_service
-      MINIO_URL: http://minio:9000
-      MINIO_EXTERNAL_URL: http://localhost:3010
+      MINIO_URL: http://minio
+      MINIO_PORT: 9000
+      MINIO_EXTERNAL_URL: http://localhost
+      MINIO_EXTERNAL_PORT: 3010
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: root
       MINIO_ACCESS_KEY: minioadmin

--- a/src/main/java/de/unistuttgart/iste/meitrex/media_service/controller/MediaController.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/media_service/controller/MediaController.java
@@ -97,6 +97,11 @@ public class MediaController {
     }
 
     @QueryMapping
+    public List<List<MediaRecord>> _internal_noauth_mediaRecordsByContentIds(@Argument final List<UUID> contentIds) {
+        return mediaService.getMediaRecordsByContentIds(contentIds);
+    }
+
+    @QueryMapping
     public List<List<MediaRecord>> mediaRecordsForCourses(@Argument final List<UUID> courseIds,
                                                           @ContextValue final LoggedInUser currentUser) {
         final List<List<MediaRecord>> mediaRecordsByContentIds = mediaService.getMediaRecordsForCourses(courseIds);

--- a/src/main/resources/graphql/service/query.graphqls
+++ b/src/main/resources/graphql/service/query.graphqls
@@ -39,9 +39,18 @@ type Query {
     Returns the media records associated the given content IDs as a list of lists where each sublist contains
     the media records associated with the content ID at the same index in the input list
 
-    🔒 If the mediaRecord is associated with coursed the user must be a member of at least one of the courses.
+    🔒 If the mediaRecord is associated with courses the user must be a member of at least one of the courses.
     """
     mediaRecordsByContentIds(contentIds: [UUID!]!): [[MediaRecord!]!]!
+
+    """
+    Returns the media records associated the given content IDs as a list of lists where each sublist contains
+    the media records associated with the content ID at the same index in the input list
+
+    ⚠️ This query is only accessible internally in the system and allows the caller to fetch contents without
+    any permissions check and should not be called without any validation of the caller's permissions. ⚠️
+    """
+    _internal_noauth_mediaRecordsByContentIds(contentIds: [UUID!]!): [[MediaRecord!]!]!
 
     """
     Returns all media records for the given CourseIds


### PR DESCRIPTION
* Allows more fine-grained config of minio through env variables `MINIO_PORT` and `MINIO_EXTERNAL_PORT`
* Adds `_internal_noauth_mediaRecordsByContentIds` query, identical to `mediaRecordsByContentIds` query but without authentication