### PR TITLE
Standardized File Conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,13 @@ RUN mkdir -p build/dependency && (cd build/dependency; jar -xf ../libs/*-SNAPSHO
 
 FROM eclipse-temurin:21-jdk
 VOLUME /tmp
+
+# Install libreoffice, we need it for document format conversion
+RUN apt-get update && apt-get install -y libreoffice && rm -rf /var/lib/apt/lists/*
+
 ARG DEPENDENCY=/workspace/app/build/dependency
 COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib
 COPY --from=build ${DEPENDENCY}/META-INF /app/META-INF
 COPY --from=build ${DEPENDENCY}/BOOT-INF/classes /app
+
 ENTRYPOINT ["java","-cp","app:app/lib/*","de.unistuttgart.iste.meitrex.media_service.MediaServiceApplication"]

--- a/src/main/java/de/unistuttgart/iste/meitrex/media_service/controller/MediaController.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/media_service/controller/MediaController.java
@@ -218,6 +218,14 @@ public class MediaController {
         return mediaService.createMediaRecordInternalUploadUrl(mediaRecord.getId());
     }
 
+    @SchemaMapping(typeName = "MediaRecord", field = "standardizedDownloadUrl")
+    public String standardizedDownloadUrl(final MediaRecord mediaRecord) {
+        if (mediaRecord.getStandardizedDownloadUrl() != null)
+            return mediaRecord.getStandardizedDownloadUrl();
+
+        return mediaService.createMediaRecordStandardizedDownloadUrl(mediaRecord.getId()).orElse(null);
+    }
+
     /**
      * Checks if the user has access to a MediaRecord in a List of MediaRecords.
      * If the user doesn't have access the mediaRecord will be set to null.

--- a/src/main/java/de/unistuttgart/iste/meitrex/media_service/controller/WebhookController.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/media_service/controller/WebhookController.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.unistuttgart.iste.meitrex.media_service.service.MediaService;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,6 +17,7 @@ import java.util.UUID;
  */
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class WebhookController {
 
     private final MediaService mediaService;
@@ -28,12 +30,23 @@ public class WebhookController {
     @SneakyThrows
     public void receiveOnMinioObjectCreateWebhook(@RequestBody String payload) {
         // the webhook payload is a JSON object with a "Records" array
+        log.info(payload);
         JsonNode root = new ObjectMapper().readTree(payload);
 
         // from the records array, get the file name of the uploaded object. File name matches the media record id
         String fileName = root.get("Records").get(0).get("s3").get("object").get("key").asText();
 
+        if(fileName.endsWith("_standardized")) {
+            // ignore standardized files, they are a conversion of an already uploaded file
+            return;
+        }
+
+        UUID mediaRecordId = UUID.fromString(fileName);
+
+        // check if this file needs to be converted to a standardized format and do so if it needs to be
+        mediaService.convertToStandardizedFileIfPossibleAndNecessary(mediaRecordId);
+
         // publish dapr event
-        mediaService.publishMediaRecordFileCreatedEvent(UUID.fromString(fileName));
+        mediaService.publishMediaRecordFileCreatedEvent(mediaRecordId);
     }
 }

--- a/src/main/java/de/unistuttgart/iste/meitrex/media_service/persistence/entity/MediaRecordEntity.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/media_service/persistence/entity/MediaRecordEntity.java
@@ -4,6 +4,7 @@ import de.unistuttgart.iste.meitrex.common.persistence.IWithId;
 import jakarta.persistence.*;
 import lombok.*;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -37,6 +38,9 @@ public class MediaRecordEntity implements IWithId<UUID> {
 
     @Column(length = 500)
     private String downloadUrl;
+
+    @Column(length = 500, nullable = true)
+    private String standardizedDownloadUrl;
 
     @ElementCollection
     private List<UUID> courseIds;

--- a/src/main/java/de/unistuttgart/iste/meitrex/media_service/service/FileConversionService.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/media_service/service/FileConversionService.java
@@ -1,0 +1,61 @@
+package de.unistuttgart.iste.meitrex.media_service.service;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.function.Consumer;
+
+@Service
+@Slf4j
+public class FileConversionService {
+    /**
+     * Converts a document to pdf using the soffice utility asynchronously. Upon successful conversion, the pdf is
+     * written to the provided output stream which can be digested in the outputStreamConsumer function.
+     * @param inputStream The input document to convert.
+     * @param outputStreamConsumer The consumer function to handle the output pdf.
+     */
+    @SneakyThrows
+    public void convertDocumentToPdf(InputStream inputStream, Consumer<InputStream> outputStreamConsumer) {
+        // create a temp file to save the input document to
+        File inputFile = File.createTempFile("doc", ".tmp", null);
+        inputFile.deleteOnExit();
+
+        // write the input document to the temp file
+        Files.copy(inputStream, inputFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+        // create a temp output directory to save the converted pdf to
+        // (the soffice utility only accepts directories as output, not a file path directly)
+        Path outputDir = Files.createTempDirectory("docout");
+        outputDir.toFile().deleteOnExit();
+
+        Thread thread = new Thread(() -> {
+            // invoke soffice to convert the input document to pdf
+            Process process = null;
+            try {
+                process = new ProcessBuilder(
+                        "soffice",
+                        "--headless",
+                        "--convert-to", "pdf",
+                        "--outdir", outputDir.toString(),
+                        inputFile.toString()).start();
+                process.waitFor();
+                try(InputStream inStream = Files.newInputStream(outputDir.resolve(
+                        inputFile.getName().substring(0, inputFile.getName().lastIndexOf(".")) + ".pdf"))) {
+                    outputStreamConsumer.accept(inStream);
+                }
+            } catch (IOException | InterruptedException e) {
+                throw new RuntimeException(e);
+            } finally {
+                if(process != null) {
+                    process.destroy();
+                }
+            }
+        });
+        thread.start();
+    }
+}

--- a/src/main/resources/graphql/service/schema.graphqls
+++ b/src/main/resources/graphql/service/schema.graphqls
@@ -38,6 +38,15 @@ type MediaRecord {
   """
   downloadUrl: String!
   """
+  Temporary download url for the media record where, if the media record is uploaded in a non-standardized format, a
+  converted version of that file is served.
+
+  For documents, this is a PDF version of the document.
+
+  May be NULL if no standardized version is available.
+  """
+  standardizedDownloadUrl: String
+  """
   Temporary upload url for the media record which can only be used from within the system.
   (This is necessary because the MinIO pre-signed URLs cannot be changed, meaning we cannot use the same URL for both
   internal and external access because the hostname changes.)

--- a/src/test/java/de/unistuttgart/iste/meitrex/media_service/service/MediaServiceTest.java
+++ b/src/test/java/de/unistuttgart/iste/meitrex/media_service/service/MediaServiceTest.java
@@ -29,8 +29,10 @@ class MediaServiceTest {
 
     private final TopicPublisher topicPublisher = mock(TopicPublisher.class);
 
+    private final FileConversionService fileConversionService = mock(FileConversionService.class);
+
     private final MediaService service = new MediaService(mockMinIoClient, mockMinIoClient, topicPublisher, repository,
-            mapper);
+            mapper, fileConversionService);
 
 
     MediaServiceTest() throws Exception {


### PR DESCRIPTION
* Convert documents & presentations to PDF if possible
* GraphQL field downloadUrl still serves the original file
* New: GraphQL field standardizedDownloadUrl serves a converted version of the file if conversion is possible