### PR TITLE
standardizedDownloadUrl: Always use minio external client to generate URL

### DIFF
--- a/src/main/java/de/unistuttgart/iste/meitrex/media_service/service/MediaService.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/media_service/service/MediaService.java
@@ -604,7 +604,7 @@ public class MediaService {
         // if we have a standardized type and the object is already of that type, return it
         if (contentType.equals(standardizedMimeType)) {
             return Optional.of(
-                    minioInternalClient.getPresignedObjectUrl(
+                    minioExternalClient.getPresignedObjectUrl(
                             GetPresignedObjectUrlArgs.builder()
                                     .method(Method.GET)
                                     .bucket(bucketId)


### PR DESCRIPTION
Fixes a bug where the standardizedDownloadUrl was generated by the minioInternalClient in some cases.

This meant the url was not accessible from external sources in cases where the internal and external url differ.